### PR TITLE
Update types format of expect-webdriverio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,9 +1582,12 @@
       }
     },
     "expect-webdriverio": {
-      "version": "0.0.1-alpha.3",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-0.0.1-alpha.3.tgz",
-      "integrity": "sha512-zPJovWVHCu3UwG5VGzghxV157D5hoDg6R46ctzBnNnCJFhm8hXe4sS9LSgJAvEeQbXGtuwPh0eP8QFeo0z4lXA=="
+      "version": "0.1.2-beta.6",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-0.1.2-beta.6.tgz",
+      "integrity": "sha512-NFvQnyX7lhjkZFIEy4vnBbm80nWExvSx+CDsmBepBcd5cPT/X9jKMusUAWj3Qc/GZgakxjLo89MGoWd0eu5KTg==",
+      "requires": {
+        "jest-matcher-utils": "^24.9.0"
+      }
     },
     "extend": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@types/jest": "^24.0.23",
     "chromedriver": "^78.0.1",
-    "expect-webdriverio": "0.0.1-alpha.3",
+    "expect-webdriverio": "^0.1.2-beta.6",
     "jest": "^24.9.0",
     "ts-jest": "^24.2.0",
     "ts-node": "^8.5.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    "types": ["node", "jest", "webdriverio", "expect-webdriverio/types/expect-webdriverio"]
+    "types": ["node", "jest", "webdriverio", "expect-webdriverio/jest"]
   }
 }


### PR DESCRIPTION
Hello!

I've published new version of `expect-webdriverio` with some fixes and had to change [types format](https://github.com/mgrybyk/expect-webdriverio#typescript).

This should not happen anymore. 

Cheers!